### PR TITLE
perf: optimize queryAllApps with conditional fetching logic

### DIFF
--- a/ozhera-app/app-api/src/main/java/org/apache/ozhera/app/api/service/HeraAppService.java
+++ b/ozhera-app/app-api/src/main/java/org/apache/ozhera/app/api/service/HeraAppService.java
@@ -72,6 +72,8 @@ public interface HeraAppService {
 
     Long countRole(HeraAppRoleModel roleModel);
 
+    List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer limit);
+
     /**
      * query user have permission project
      *

--- a/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/dao/mapper/HeraAppBaseInfoMapper.java
+++ b/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/dao/mapper/HeraAppBaseInfoMapper.java
@@ -40,6 +40,8 @@ public interface HeraAppBaseInfoMapper extends BaseMapper<HeraAppBaseInfo> {
 
     List<AppBaseInfo> queryAppInfo(@Param("appName") String appName, @Param("platformType") Integer platformType, @Param("type") Integer type);
 
+    List<AppBaseInfo> queryLatestAppInfo(@Param("limit") Integer limit);
+
     List<AppBaseInfo> queryByIds(List<Long> ids);
 
     List<HeraAppBaseInfoParticipant> selectByParticipant(HeraAppBaseQuery query);

--- a/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/service/impl/HeraAppServiceImpl.java
+++ b/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/service/impl/HeraAppServiceImpl.java
@@ -105,6 +105,23 @@ public class HeraAppServiceImpl implements HeraAppService {
         return appBaseInfos;
     }
 
+    public List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer type) {
+        List<AppBaseInfo> appBaseInfos;
+        if (Objects.nonNull(appName)) {
+            appBaseInfos = heraAppBaseInfoMapper.queryAppInfo(appName, null, null);
+        }else{
+            appBaseInfos = heraAppBaseInfoMapper.queryLatestAppInfo(100);
+        }
+        if (CollectionUtils.isNotEmpty(appBaseInfos)) {
+            appBaseInfos = appBaseInfos.parallelStream().map(appBaseInfo -> {
+                appBaseInfo.setPlatformName(appTypeServiceExtension.getPlatformName(appBaseInfo.getPlatformType()));
+                appBaseInfo.setAppTypeName(appTypeServiceExtension.getAppTypeName(appBaseInfo.getAppType()));
+                return appBaseInfo;
+            }).collect(Collectors.toList());
+        }
+        return appBaseInfos;
+    }
+
     @Override
     public List<AppBaseInfo> queryAllExistsApp() {
         return queryAppInfoWithLog("", null);

--- a/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/service/impl/HeraAppServiceImpl.java
+++ b/ozhera-app/app-service/src/main/java/org/apache/ozhera/app/service/impl/HeraAppServiceImpl.java
@@ -105,12 +105,13 @@ public class HeraAppServiceImpl implements HeraAppService {
         return appBaseInfos;
     }
 
-    public List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer type) {
+    @Override
+    public List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer limit) {
         List<AppBaseInfo> appBaseInfos;
-        if (Objects.nonNull(appName)) {
+        if (appName != null && !appName.isEmpty()) {
             appBaseInfos = heraAppBaseInfoMapper.queryAppInfo(appName, null, null);
         }else{
-            appBaseInfos = heraAppBaseInfoMapper.queryLatestAppInfo(100);
+            appBaseInfos = heraAppBaseInfoMapper.queryLatestAppInfo(limit);
         }
         if (CollectionUtils.isNotEmpty(appBaseInfos)) {
             appBaseInfos = appBaseInfos.parallelStream().map(appBaseInfo -> {

--- a/ozhera-app/app-service/src/main/resources/mapper/HeraAppBaseInfoMapper.xml
+++ b/ozhera-app/app-service/src/main/resources/mapper/HeraAppBaseInfoMapper.xml
@@ -668,7 +668,7 @@
                he.tree_ids      AS treeIds,
                he.node_ips      AS nodeIPs
         FROM hera_app_base_info hb
-                 LEFT JOIN hera_extension he ON hb.id = he.app_id
+                 LEFT JOIN hera_app_excess_info he ON hb.id = he.app_base_id
         ORDER BY
             hb.update_time DESC
         LIMIT #{limit}

--- a/ozhera-app/app-service/src/main/resources/mapper/HeraAppBaseInfoMapper.xml
+++ b/ozhera-app/app-service/src/main/resources/mapper/HeraAppBaseInfoMapper.xml
@@ -658,6 +658,22 @@
         </where>
     </select>
 
+    <select id="queryLatestAppInfo" resultMap="queryAppResultMap">
+        SELECT hb.id            AS id,
+               hb.bind_id       AS bindId,
+               hb.app_name      AS appName,
+               hb.app_cname     AS appCname,
+               hb.app_type      AS appType,
+               hb.platform_type AS platformType,
+               he.tree_ids      AS treeIds,
+               he.node_ips      AS nodeIPs
+        FROM hera_app_base_info hb
+                 LEFT JOIN hera_extension he ON hb.id = he.app_id
+        ORDER BY
+            hb.update_time DESC
+        LIMIT #{limit}
+    </select>
+
     <select id="countNormalData" resultType="java.lang.Long">
         SELECT
             count(*)

--- a/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/HeraAppService.java
+++ b/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/HeraAppService.java
@@ -60,4 +60,6 @@ public interface HeraAppService {
     int delById(Integer id);
 
     Long getAppCount();
+
+    List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer limit);
 }

--- a/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/impl/HeraAppServiceImpl.java
+++ b/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/impl/HeraAppServiceImpl.java
@@ -63,6 +63,11 @@ public class HeraAppServiceImpl implements HeraAppService {
     }
 
     @Override
+    public List<AppBaseInfo> querySpecifiedAppInfoWithLog(String appName, Integer limit) {
+        return heraAppService.querySpecifiedAppInfoWithLog(appName, limit);
+    }
+
+    @Override
     public List<AppBaseInfo> queryAllExistsApp() {
         return heraAppService.queryAllExistsApp();
     }

--- a/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/impl/LogTailServiceImpl.java
+++ b/ozhera-log/log-manager/src/main/java/org/apache/ozhera/log/manager/service/impl/LogTailServiceImpl.java
@@ -540,7 +540,8 @@ public class LogTailServiceImpl extends BaseService implements LogTailService {
     }
 
     private List<MapDTO> queryAppInfo(String appName, Integer type) {
-        List<AppBaseInfo> apps = heraAppService.queryAppInfoWithLog(appName, type);
+        int limit = 100;
+        List<AppBaseInfo> apps = heraAppService.querySpecifiedAppInfoWithLog(appName, limit);
         List<MapDTO> mapDTOList = Lists.newArrayList();
         if (CollectionUtils.isNotEmpty(apps)) {
             mapDTOList = apps.stream().map(response -> {


### PR DESCRIPTION
<!--

    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
    regarding copyright ownership.  The ASF licenses this file
    to you under the Apache License, Version 2.0 (the
    "License"); you may not use this file except in compliance
    with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

    Unless required by applicable law or agreed to in writing,
    software distributed under the License is distributed on an
    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.

-->

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
- Modify queryAllApps to perform fuzzy search by name when provided
- Implement fallback to fetch top 100 records when no name filter exists
- Reduce full-table scan overhead and improve query performance

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
None.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
No need testing

### Ⅳ. Describe how to verify it
Returns 100 data when appName is empty

### Ⅴ. Special notes for reviews
None.
